### PR TITLE
feat: add clinic backend skeleton

### DIFF
--- a/packages/clinic-backend/jest.config.js
+++ b/packages/clinic-backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts']
+};

--- a/packages/clinic-backend/package.json
+++ b/packages/clinic-backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "clinic-backend",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf dist",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "5.1.0"
+  },
+  "devDependencies": {
+    "@n8n/typescript-config": "workspace:*",
+    "@types/node": "*",
+    "@types/express": "^4.17.21",
+    "ts-jest": "^29.1.1",
+    "typescript": "*",
+    "supertest": "^7.0.0",
+    "@types/supertest": "^6.0.2"
+  }
+}

--- a/packages/clinic-backend/src/index.ts
+++ b/packages/clinic-backend/src/index.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/leads', (req, res) => {
+  // placeholder lead handling
+  const lead = req.body;
+  res.status(201).json({ message: 'Lead received', lead });
+});
+
+app.post('/verify-insurance', (req, res) => {
+  const info = req.body;
+  // placeholder verification logic
+  res.json({ eligible: true, info });
+});
+
+app.post('/book-appointment', (req, res) => {
+  const appointment = req.body;
+  res.status(201).json({ message: 'Appointment booked', appointment });
+});
+
+export default app;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Clinic backend listening on port ${port}`);
+  });
+}

--- a/packages/clinic-backend/test/server.test.ts
+++ b/packages/clinic-backend/test/server.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../src/index';
+
+describe('Clinic backend', () => {
+  it('health endpoint works', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+});

--- a/packages/clinic-backend/tsconfig.build.json
+++ b/packages/clinic-backend/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/clinic-backend/tsconfig.json
+++ b/packages/clinic-backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@n8n/typescript-config/tsconfig.common.json", "@n8n/typescript-config/tsconfig.backend.json"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/build.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["test/**"]
+}


### PR DESCRIPTION
## Summary
- create new `clinic-backend` package
- implement small Express server with health and placeholder routes
- include minimal Jest test

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.2.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684559340d308329b6d959ebaa08943b